### PR TITLE
fix: fix visual inconsistencies in text

### DIFF
--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -25,7 +25,7 @@ export default function Music() {
         const csvData = await fetchSheet(sheetTabGid);
         const parsedData: IFrameProps[] = parseCsv<IFrameProps>(
           csvData,
-          (row) => !!row.title && !!row.type,
+          (row) => !!row.title && !!row.type
         );
 
         console.log("Parsed Music Content:", parsedData);
@@ -35,9 +35,9 @@ export default function Music() {
         const uniqueCategories = Array.from(
           new Set(
             parsedData.map(
-              (item) => item[categoryKey as keyof IFrameProps] || "",
-            ),
-          ),
+              (item) => item[categoryKey as keyof IFrameProps] || ""
+            )
+          )
         );
 
         setCategories(uniqueCategories);
@@ -58,7 +58,7 @@ export default function Music() {
       : iFrames.filter(
           (item) =>
             item[(isFrench ? "categorie" : "category") as keyof IFrameProps] ===
-            selectedCategory,
+            selectedCategory
         );
 
   return (
@@ -70,7 +70,7 @@ export default function Music() {
         {categories.map((category) => (
           <button
             key={category}
-            className={`py-2 px-4 rounded-full transition-colors duration-200 text-nowrap ${
+            className={`py-2 px-4 rounded-full transition-colors duration-200 text-nowrap font-blanch text-2xl ${
               selectedCategory === category
                 ? "bg-clarks-orange text-black"
                 : "bg-gray-200 text-gray-800 hover:bg-gray-300"
@@ -94,7 +94,7 @@ export default function Music() {
             <Spotify key={item.title} src={item.src} title={item.title} />
           ) : (
             <Youtube key={item.title} src={item.src} title={item.title} />
-          ),
+          )
         )}
       </div>
     </>

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -70,7 +70,7 @@ export default function Music() {
         {categories.map((category) => (
           <button
             key={category}
-            className={`py-2 px-4 rounded-full transition-colors duration-200 text-nowrap font-blanch text-2xl ${
+            className={`py-2 px-4 rounded-full transition-colors duration-200 text-nowrap ${
               selectedCategory === category
                 ? "bg-clarks-orange text-black"
                 : "bg-gray-200 text-gray-800 hover:bg-gray-300"

--- a/src/components/TourDates/TourDatesContainer.tsx
+++ b/src/components/TourDates/TourDatesContainer.tsx
@@ -12,7 +12,7 @@ export default function TourDatesContainer({
 }: TourDatesContainerProps) {
   return (
     <div className="mb-10">
-      <h3 className="text-3xl pb-10">{title}</h3>
+      <h3 className="text-3xl pb-10 font-blanch">{title}</h3>
       <div className="flex flex-col">
         {tourDates.map((tourDate) => (
           <TourDate


### PR DESCRIPTION
Changed the fonts so that headings in the Tour section and buttons in the Music section now look more visually consistent

## Before

![Screenshot 2025-01-27 at 15 44 51](https://github.com/user-attachments/assets/9e6e78cc-2630-41d1-ae05-a59c53a39535)
![Screenshot 2025-01-27 at 15 44 58](https://github.com/user-attachments/assets/ecae68b9-0a93-4302-b947-f3cc227fe5eb)

## After 

![Screenshot 2025-01-27 at 15 47 41](https://github.com/user-attachments/assets/9f53227c-fc6c-49b7-aa12-75063e3491d4)
![Screenshot 2025-01-27 at 15 50 14](https://github.com/user-attachments/assets/8c2f9847-aab0-426c-a346-ff7488f6d9ed)
![Screenshot 2025-01-27 at 15 50 20](https://github.com/user-attachments/assets/75941287-c6fc-4f0f-a665-4a552823cfe7)

