### PR TITLE
Accessibility improvements for WCAG 2.1 AA

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { Metadata } from "next";
 import { useLanguage } from "@/context/LanguageContext";
 import { Page } from "@/utils/types";
 import Carousel from "@/components/ui/Carousel";
@@ -13,7 +14,17 @@ const carouselImages = [
   "/images/carousel/leaving.jpg",
   "/images/carousel/yesday.jpg",
 ];
+const carouselAlts = [
+  "Black and white band portrait",
+  "Band posing together",
+  "Leaving the stage after a show",
+  "Performing at Yes Day festival",
+];
 const sheetTabGid = 0;
+
+export const metadata: Metadata = {
+  title: "About",
+};
 
 export default function About() {
   const { isFrench } = useLanguage();
@@ -40,13 +51,17 @@ export default function About() {
     setPageContent(isFrench ? frenchContent : englishContent);
   }, [isFrench, frenchContent, englishContent]);
 
+  useEffect(() => {
+    document.title = `${isFrench ? 'À propos' : 'About'} | Clark's Bowling Club`;
+  }, [isFrench]);
+
   if (!pageContent) return <div>Loading...</div>;
 
   return (
     <>
       <h1 className="text-4xl font-blanch mb-6">{pageContent.title}</h1>
       <p className="text-lg leading-relaxed mb-8">{pageContent.content}</p>
-      <Carousel images={carouselImages} />
+      <Carousel images={carouselImages} altTexts={carouselAlts} />
     </>
   );
 }

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,6 +3,8 @@
 import ContactForm from "@/components/ui/ContactForm";
 import { useLanguage } from "@/context/LanguageContext";
 import { Page } from "@/utils/types";
+import { useEffect } from "react";
+import type { Metadata } from "next";
 
 const french: Page = {
   title: "Contact",
@@ -14,9 +16,17 @@ const english: Page = {
   content: "Send us a message",
 };
 
+export const metadata: Metadata = {
+  title: "Contact",
+};
+
 export default function Tour() {
   const { isFrench } = useLanguage();
   const pageContent = isFrench ? french : english;
+
+  useEffect(() => {
+    document.title = `${isFrench ? "Contact" : "Contact"} | Clark's Bowling Club`;
+  }, [isFrench]);
 
   return (
     <>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,10 @@ const goudyStd = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "Clark's Bowling Club",
+  title: {
+    default: "Clark's Bowling Club",
+    template: "%s | Clark's Bowling Club",
+  },
   description:
     "Clark’s Bowling Club is a 6-piece funk/pop band based in Lyon, France. Inspired by the likes of Jungle and Deluxe, their music brings a modern twist to disco-funk, hip-hop, and jazz genres, breathing new life into the vibrant music scene.",
 };

--- a/src/app/lyrics/page.tsx
+++ b/src/app/lyrics/page.tsx
@@ -4,11 +4,16 @@ import { useLanguage } from "@/context/LanguageContext";
 import fetchSheet from "@/utils/fetchSheet";
 import parseCsv from "@/utils/parseCsv";
 import { useEffect, useState } from "react";
+import type { Metadata } from "next";
 import clsx from "clsx";
 import { LyricsProps } from "@/utils/types";
 import FilterButton from "@/components/ui/FilterButton";
 
 const sheetTabGid = 145198726;
+
+export const metadata: Metadata = {
+  title: "Lyrics",
+};
 
 export default function Music() {
   const { isFrench } = useLanguage();
@@ -16,6 +21,8 @@ export default function Music() {
   const [albums, setAlbums] = useState<string[]>([]);
   const [selectedAlbum, setSelectedAlbum] = useState<string | undefined>();
   const [selectedSong, setSelectedSong] = useState<LyricsProps | undefined>();
+  const [albumAnnouncement, setAlbumAnnouncement] = useState("");
+  const [songAnnouncement, setSongAnnouncement] = useState("");
 
   useEffect(() => {
     const fetchContent = async () => {
@@ -65,6 +72,28 @@ export default function Music() {
   const filteredSongs = selectedAlbum
     ? lyrics.filter((song) => song.album === selectedAlbum)
     : [];
+
+  useEffect(() => {
+    document.title = `${isFrench ? "Paroles" : "Lyrics"} | Clark's Bowling Club`;
+  }, [isFrench]);
+
+  useEffect(() => {
+    setAlbumAnnouncement(
+      isFrench
+        ? `${filteredSongs.length} chansons dans l'album ${selectedAlbum}`
+        : `${filteredSongs.length} songs from album ${selectedAlbum}`
+    );
+  }, [filteredSongs.length, selectedAlbum, isFrench]);
+
+  useEffect(() => {
+    if (selectedSong) {
+      setSongAnnouncement(
+        isFrench
+          ? `Paroles affichées pour ${selectedSong.title}`
+          : `Showing lyrics for ${selectedSong.title}`
+      );
+    }
+  }, [selectedSong, isFrench]);
 
   return (
     <>
@@ -116,6 +145,8 @@ export default function Music() {
           )}
         </div>
       </div>
+      <div aria-live="polite" className="sr-only">{albumAnnouncement}</div>
+      <div aria-live="polite" className="sr-only">{songAnnouncement}</div>
     </>
   );
 }

--- a/src/app/merch/page.tsx
+++ b/src/app/merch/page.tsx
@@ -2,6 +2,8 @@
 
 import { useLanguage } from "@/context/LanguageContext";
 import { Page } from "@/utils/types";
+import { useEffect } from "react";
+import type { Metadata } from "next";
 
 const french: Page = {
   title: "Boutique",
@@ -13,9 +15,17 @@ const english: Page = {
   content: "Coming soon!",
 };
 
+export const metadata: Metadata = {
+  title: "Merch",
+};
+
 export default function Tour() {
   const { isFrench } = useLanguage();
   const pageContent = isFrench ? french : english;
+
+  useEffect(() => {
+    document.title = `${isFrench ? "Boutique" : "Merch"} | Clark's Bowling Club`;
+  }, [isFrench]);
 
   return (
     <>

--- a/src/app/music/page.tsx
+++ b/src/app/music/page.tsx
@@ -8,9 +8,14 @@ import { IFrameProps } from "@/utils/types";
 import fetchSheet from "@/utils/fetchSheet";
 import parseCsv from "@/utils/parseCsv";
 import { useEffect, useState } from "react";
+import type { Metadata } from "next";
 import FilterButton from "@/components/ui/FilterButton";
 
 const sheetTabGid = 1713768433;
+
+export const metadata: Metadata = {
+  title: "Music",
+};
 
 export default function Music() {
   const { isFrench } = useLanguage();
@@ -19,6 +24,7 @@ export default function Music() {
   const [selectedCategory, setSelectedCategory] = useState<
     string | number | readonly string[] | undefined
   >("Live Performances");
+  const [announcement, setAnnouncement] = useState("");
 
   useEffect(() => {
     const fetchContent = async () => {
@@ -62,6 +68,18 @@ export default function Music() {
             selectedCategory
         );
 
+  useEffect(() => {
+    document.title = `${isFrench ? "Musique" : "Music"} | Clark's Bowling Club`;
+  }, [isFrench]);
+
+  useEffect(() => {
+    setAnnouncement(
+      isFrench
+        ? `${filteredIFrames.length} éléments dans la catégorie ${selectedCategory}`
+        : `${filteredIFrames.length} items in category ${selectedCategory}`
+    );
+  }, [filteredIFrames.length, selectedCategory, isFrench]);
+
   return (
     <>
       <h1 className="text-4xl font-blanch mb-6">
@@ -93,6 +111,7 @@ export default function Music() {
           )
         )}
       </div>
+      <div aria-live="polite" className="sr-only">{announcement}</div>
     </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,26 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, useEffect } from "react";
+import { useLanguage } from "@/context/LanguageContext";
+import type { Metadata } from "next";
 import { FaVolumeMute, FaVolumeUp, FaPause, FaPlay } from "react-icons/fa";
 import SpinningLogo from "@/components/Home/SpinningLogo";
 import Image from "next/image";
 import StaticLogo from "@/components/Home/StaticLogo";
 
+export const metadata: Metadata = {
+  title: "Home",
+};
+
 export default function Home() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [muted, setMuted] = useState(true);
   const [play, setPlay] = useState(true);
+  const { isFrench } = useLanguage();
+
+  useEffect(() => {
+    document.title = `${isFrench ? 'Accueil' : 'Home'} | Clark's Bowling Club`;
+  }, [isFrench]);
 
   const backgroundClasses =
     "absolute inset-0 top-0 left-0 min-h-full w-auto object-cover";
@@ -47,7 +58,7 @@ export default function Home() {
         />
         <Image
           src="/images/home.png"
-          alt=""
+          alt="Band performing on stage"
           fill
           className={`${backgroundClasses} motion-reduce:block hidden`}
         />

--- a/src/app/privacy-policy/page.tsx
+++ b/src/app/privacy-policy/page.tsx
@@ -2,10 +2,21 @@
 
 import Link from "next/link";
 import { useLanguage } from "@/context/LanguageContext";
+import { useEffect } from "react";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy",
+};
 
 export default function PrivacyPolicy() {
   const email = "contact@clarksbowlingclub.com";
   const { isFrench } = useLanguage();
+  useEffect(() => {
+    document.title = `${
+      isFrench ? 'Politique de Confidentialité' : 'Privacy Policy'
+    } | Clark's Bowling Club`;
+  }, [isFrench]);
   return (
     <>
       <h1 className="text-4xl font-blanch mb-6">

--- a/src/app/tour/page.tsx
+++ b/src/app/tour/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useLanguage } from "@/context/LanguageContext";
 import { Page, TourDateType } from "@/utils/types";
+import type { Metadata } from "next";
 
 import fetchSheet from "@/utils/fetchSheet";
 import parseCsv from "@/utils/parseCsv";
@@ -13,6 +14,10 @@ import TourDatesContainer from "@/components/TourDates/TourDatesContainer";
 
 const sheetTabGid = 127405583; // Main Tour page content
 const sheetTabGidTourDates = 572869052; // Tour dates
+
+export const metadata: Metadata = {
+  title: "Tour",
+};
 
 export default function Tour() {
   const { isFrench } = useLanguage();
@@ -48,6 +53,10 @@ export default function Tour() {
   useEffect(() => {
     setPageContent(isFrench ? frenchContent : englishContent);
   }, [isFrench, englishContent, frenchContent]);
+
+  useEffect(() => {
+    document.title = `${isFrench ? 'Tournée' : 'Tour'} | Clark's Bowling Club`;
+  }, [isFrench]);
 
   useEffect(() => {
     const past: TourDateType[] = [];

--- a/src/components/ui/Carousel.tsx
+++ b/src/components/ui/Carousel.tsx
@@ -1,14 +1,18 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 import Image from "next/image";
 import clsx from "clsx";
 
 interface CarouselProps {
   images: string[];
+  altTexts?: string[];
 }
 
-export default function Carousel({ images }: CarouselProps) {
+export default function Carousel({ images, altTexts }: CarouselProps) {
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [announcement, setAnnouncement] = useState(
+    `Slide 1 of ${images.length}: ${altTexts?.[0] || "Band image"}`
+  );
 
   const nextSlide = () => {
     setCurrentIndex((prevIndex) =>
@@ -21,6 +25,11 @@ export default function Carousel({ images }: CarouselProps) {
       prevIndex === 0 ? images.length - 1 : prevIndex - 1
     );
   };
+
+  useEffect(() => {
+    const alt = altTexts?.[currentIndex] || `Band image ${currentIndex + 1}`;
+    setAnnouncement(`Slide ${currentIndex + 1} of ${images.length}: ${alt}`);
+  }, [currentIndex, altTexts, images.length]);
 
   return (
     <div className="relative w-full h-96 overflow-hidden rounded-lg">
@@ -35,7 +44,7 @@ export default function Carousel({ images }: CarouselProps) {
             height={500}
             key={index}
             src={image}
-            alt={`Slide ${index + 1}`}
+            alt={altTexts?.[index] || `Band image ${index + 1}`}
             className="w-full h-full object-cover flex-shrink-0"
           />
         ))}
@@ -72,6 +81,9 @@ export default function Carousel({ images }: CarouselProps) {
             role="button"
           />
         ))}
+      </div>
+      <div aria-live="polite" className="sr-only">
+        {announcement}
       </div>
     </div>
   );

--- a/src/components/ui/Checkbox.tsx
+++ b/src/components/ui/Checkbox.tsx
@@ -26,18 +26,18 @@ export default function Checkbox({
   required = false,
 }: CheckboxProps) {
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const [error, setError] = useState("");
   const { isFrench } = useLanguage();
 
   const handleInvalid = (e: React.FormEvent<HTMLInputElement>) => {
+    e.preventDefault();
     if (e.currentTarget.validity.valueMissing) {
-      e.currentTarget.setCustomValidity(
-        isFrench ? "Ce champ est obligatoire" : "This field is required"
-      );
+      setError(isFrench ? "Ce champ est obligatoire" : "This field is required");
     }
   };
 
-  const handleInput = (e: React.FormEvent<HTMLInputElement>) => {
-    e.currentTarget.setCustomValidity("");
+  const handleInput = () => {
+    setError("");
   };
 
   useEffect(() => {
@@ -55,15 +55,29 @@ export default function Checkbox({
   return (
     <div className="flex gap-2 pb-6 col-span-2">
       {prefersReducedMotion ? (
-        <input
-          id={id}
-          name={name}
-          type="checkbox"
-          required={required}
-          className="block"
-          onInvalid={handleInvalid}
-          onInput={handleInput}
-        />
+        <>
+          <input
+            id={id}
+            name={name}
+            type="checkbox"
+            required={required}
+            className="block"
+            onInvalid={handleInvalid}
+            onInput={handleInput}
+            aria-invalid={!!error}
+            aria-describedby={error ? `${id}-error` : undefined}
+          />
+          {error && (
+            <p
+              id={`${id}-error`}
+              className="mt-1 text-red-600"
+              role="alert"
+              aria-live="polite"
+            >
+              {error}
+            </p>
+          )}
+        </>
       ) : (
         <div className="checkbox-wrapper-30">
           <span className="checkbox">
@@ -75,6 +89,8 @@ export default function Checkbox({
               className="block focus:ring-2 focus:ring-clarks-orange focus:outline-none"
               onInvalid={handleInvalid}
               onInput={handleInput}
+              aria-invalid={!!error}
+              aria-describedby={error ? `${id}-error` : undefined}
             />
             <svg>
               <use xlinkHref="#checkbox-30" className="checkbox"></use>
@@ -91,6 +107,16 @@ export default function Checkbox({
             </symbol>
           </svg>
         </div>
+      )}
+      {error && !prefersReducedMotion && (
+        <p
+          id={`${id}-error`}
+          className="mt-1 text-red-600"
+          role="alert"
+          aria-live="polite"
+        >
+          {error}
+        </p>
       )}
       <label htmlFor={id} className={twMerge("text-sm/6", labelClass)}>
         {label}{" "}

--- a/src/components/ui/ContactForm.tsx
+++ b/src/components/ui/ContactForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useState } from "react";
+import { FormEvent, useState, useRef } from "react";
 import { toast } from "react-hot-toast";
 
 import TextInput from "./TextInput";
@@ -21,6 +21,7 @@ export default function ContactForm({ legend }: { legend: string }) {
   );
 
   const [formData, setFormData] = useState(contactForm);
+  const formRef = useRef<HTMLFormElement>(null);
   const { isFrench } = useLanguage();
 
   const handleChange = (e: { target: { name: string; value: string } }) => {
@@ -28,8 +29,14 @@ export default function ContactForm({ legend }: { legend: string }) {
     setFormData((prevData) => ({ ...prevData, [name]: value }));
   };
 
-  async function handleSubmit(e: FormEvent) {
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
+    if (formRef.current && !formRef.current.checkValidity()) {
+      formRef.current.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+        ':invalid'
+      )?.focus();
+      return;
+    }
     const fd = new FormData();
     for (const key in formData) {
       fd.append(key, formData[key]);
@@ -60,7 +67,12 @@ export default function ContactForm({ legend }: { legend: string }) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="mt-10">
+    <form
+      ref={formRef}
+      noValidate
+      onSubmit={handleSubmit}
+      className="mt-10"
+    >
       <fieldset className="grid gap-x-8 gap-y-6">
         <legend className="text-lg leading-relaxed mb-8">{legend}</legend>
         {contact_form.map((field) => (

--- a/src/components/ui/FilterButton.tsx
+++ b/src/components/ui/FilterButton.tsx
@@ -21,6 +21,7 @@ export default function FilterButton({
           : "bg-gray-200 text-gray-800 hover:bg-gray-300"
       )}
       onClick={onClick}
+      aria-pressed={isSelected}
       {...props}
     >
       {filter}

--- a/src/components/ui/TextInput.tsx
+++ b/src/components/ui/TextInput.tsx
@@ -1,5 +1,5 @@
 import { twMerge } from "tailwind-merge";
-
+import { useState } from "react";
 import { useLanguage } from "@/context/LanguageContext";
 
 interface InputProps {
@@ -32,6 +32,7 @@ export default function TextInput({
   long = false,
 }: InputProps) {
   const { isFrench } = useLanguage();
+  const [error, setError] = useState("");
   const baseClasses =
     "block w-full bg-slate-950 border-white px-3.5 py-2 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-clarks-orange sm:text-sm/6 mt-2.5 focus:outline-none";
 
@@ -39,14 +40,12 @@ export default function TextInput({
     e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>
   ) => {
     if (e.currentTarget.validity.valueMissing) {
-      e.currentTarget.setCustomValidity(
-        isFrench ? "Ce champ est obligatoire" : "This field is required"
-      );
+      setError(isFrench ? "Ce champ est obligatoire" : "This field is required");
     } else if (
       e.currentTarget.validity.typeMismatch &&
       e.currentTarget.type === "email"
     ) {
-      e.currentTarget.setCustomValidity(
+      setError(
         isFrench
           ? "Veuillez entrer une adresse e-mail valide"
           : "Please enter a valid email address"
@@ -54,10 +53,8 @@ export default function TextInput({
     }
   };
 
-  const handleInput = (
-    e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
-    e.currentTarget.setCustomValidity("");
+  const handleInput = () => {
+    setError("");
   };
 
   return (
@@ -77,29 +74,57 @@ export default function TextInput({
         ) : null}
       </label>
       {long ? (
-        <textarea
-          id={id}
-          name={name}
-          rows={4}
-          value={value}
-          onChange={onChange}
-          className={twMerge(baseClasses, inputClass)}
-          required={required}
-          onInvalid={handleInvalid}
-          onInput={handleInput}
-        />
+        <>
+          <textarea
+            id={id}
+            name={name}
+            rows={4}
+            value={value}
+            onChange={onChange}
+            className={twMerge(baseClasses, inputClass)}
+            required={required}
+            onInvalid={handleInvalid}
+            onInput={handleInput}
+            aria-invalid={!!error}
+            aria-describedby={error ? `${id}-error` : undefined}
+          />
+          {error && (
+            <p
+              id={`${id}-error`}
+              className="mt-1 text-red-600"
+              role="alert"
+              aria-live="polite"
+            >
+              {error}
+            </p>
+          )}
+        </>
       ) : (
-        <input
-          id={id}
-          name={name}
-          type={type}
-          value={value}
-          onChange={onChange}
-          className={twMerge(baseClasses, inputClass)}
-          required={required}
-          onInvalid={handleInvalid}
-          onInput={handleInput}
-        />
+        <>
+          <input
+            id={id}
+            name={name}
+            type={type}
+            value={value}
+            onChange={onChange}
+            className={twMerge(baseClasses, inputClass)}
+            required={required}
+            onInvalid={handleInvalid}
+            onInput={handleInput}
+            aria-invalid={!!error}
+            aria-describedby={error ? `${id}-error` : undefined}
+          />
+          {error && (
+            <p
+              id={`${id}-error`}
+              className="mt-1 text-red-600"
+              role="alert"
+              aria-live="polite"
+            >
+              {error}
+            </p>
+          )}
+        </>
       )}
     </div>
   );

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -67,6 +67,10 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
     setIsFrench(value);
   }, []);
 
+  useEffect(() => {
+    document.documentElement.lang = isFrench ? "fr" : "en";
+  }, [isFrench]);
+
   const value = {
     isFrench,
     setIsFrench: handleSetIsFrench,


### PR DESCRIPTION
## Summary
- adjust document lang in LanguageContext
- improve contact form validation with custom errors
- announce filter changes on music and lyrics pages
- enhance carousel with alt text and live announcements
- expose checkbox and text input errors with aria attributes
- make announcements more descriptive and update page titles
- use metadata templates for page titles and add missing alt text

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685474f91a98832a9a4d4e3bc99021d0